### PR TITLE
pass wrapped function to onAsync function

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -108,7 +108,7 @@ function asyncWrap(original, list, length) {
      * after if the listener doesn't return a value.
      */
     values[i] = list[i].domain;
-    var value = list[i].listener.call(this);
+    var value = list[i].listener.call(this, original);
     if (typeof value !== 'undefined') values[i] = value;
   }
   inAsyncTick = false;


### PR DESCRIPTION
Just and idea I had.

Pass the function being wrapped to your `onAsync` function. This is mostly useful for debugging purposes.

``` javascript
function onAsync(f) {
  process._rawDebug('async function %s scheduled', f.name);
  return f.name;
}

var handleTrace = {
  before: function before(context, trace) {
    process._rawDebug('before async function %s invoked', trace);
  },
  after: function after(context, trace, returnVal) {
    process._rawDebug('after async function %s invoked', trace);
  },
  error: function error(trace, err) {
    process._rawDebug('error in async function %s invoked', trace);
  }
};

process.addAsyncListener(onAsync, handleTrace);
```
