### PR TITLE
Don't try to wrap socket "onread" when socket is already closed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,9 @@ if (!net._normalizeConnectArgs) {
 wrap(net.Server.prototype, '_listen2', function (original) {
   return function () {
     this.on('connection', function (socket) {
-      socket._handle.onread = wrapCallback(socket._handle.onread);
+      if (socket._handle) {
+        socket._handle.onread = wrapCallback(socket._handle.onread);
+      }
     });
 
     try {

--- a/test/connection-handler-disconnects.tap.js
+++ b/test/connection-handler-disconnects.tap.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var net = require('net');
+var test = require('tap').test;
+if (!process.addAsyncListener) require('../index.js');
+
+var PORT = 12346;
+
+test("another connection handler disconnects server", function (t) {
+    t.plan(3);
+
+    // This tests that we don't crash when another connection listener
+    // destroys the socket handle before we try to wrap
+    // socket._handle.onread .
+    // In this case, the connection handler declared below will run first,
+    // because the wrapping event handler doesn't get added until
+    // the server listens below.
+
+    var server = net.createServer(function() {});
+    server.on(
+        'connection',
+        function (socket) {
+            socket.destroy();
+            t.ok(! socket._handle, 'Destroy removed the socket handle');
+        }
+    );
+
+    server.on(
+        'listening',
+        function () {
+            t.ok('Server listened ok');
+
+            // This will run both 'connection' handlers, with the one above
+            // running first.
+            // This should succeed even though the socket is destroyed.
+            var client = net.connect(PORT);
+            client.on(
+                'connect',
+                function () {
+                    t.ok(true, 'connected ok');
+                    client.destroy();
+                    server.close();
+                }
+            );
+        }
+    );
+
+    // Another 'connection' handler is registered during this call.
+    server.listen(PORT);
+
+});
+


### PR DESCRIPTION
In order to wrap socket._handle.onread, we hook into the server's 'connection' event with the aim of wrapping the onread function before request handling begins.

However, it is possible that other 'connection' event handlers will run before ours, and they may close the connection before we get a chance to run. In that case, socket._handle is already gone and there is no
longer any onread function for us to wrap, so we just do nothing.

I believe this resolves issue #13.
