### PR TITLE
Fix node 0.11

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -312,7 +312,7 @@ else {
       catch (er) {
         threw = true;
         for (var i = 0; i < length; ++i) {
-          if ((listeners[i].flags & HAS_ERROR_AL) > 0) continue;
+          if ((listeners[i].flags & HAS_ERROR_AL) == 0) continue;
           try {
             handled = listeners[i].error(values[list[i].uid], er) || handled;
           }

--- a/test/connection-handler-disconnects.tap.js
+++ b/test/connection-handler-disconnects.tap.js
@@ -7,7 +7,9 @@ if (!process.addAsyncListener) require('../index.js');
 var PORT = 12346;
 
 test("another connection handler disconnects server", function (t) {
-    t.plan(5);
+    t.plan(7);
+
+    var client;
 
     // This tests that we don't crash when another connection listener
     // destroys the socket handle before we try to wrap
@@ -20,6 +22,7 @@ test("another connection handler disconnects server", function (t) {
     server.on(
         'connection',
         function (socket) {
+            t.ok(true, 'Reached second connection event');
             socket.destroy();
             t.ok(! socket._handle, 'Destroy removed the socket handle');
         }
@@ -37,12 +40,11 @@ test("another connection handler disconnects server", function (t) {
             // This will run both 'connection' handlers, with the one above
             // running first.
             // This should succeed even though the socket is destroyed.
-            var client = net.connect(PORT);
+            client = net.connect(PORT);
             client.on(
                 'connect',
                 function () {
                     t.ok(true, 'connected ok');
-                    client.destroy();
                 }
             );
 
@@ -50,6 +52,11 @@ test("another connection handler disconnects server", function (t) {
                 'close',
                 function () {
                     t.ok(true, 'disconnected ok');
+                    t.ok(
+                        !client._handle,
+                        'close removed the client handle'
+                    );
+
                     server.close(function () {
                         t.ok(
                             !server._handle,

--- a/test/handle.tap.js
+++ b/test/handle.tap.js
@@ -28,7 +28,7 @@ test('synchronous errors during connect return a null _handle', function(t){
       // try to reconnect, but this has an error
       // rather than throw the right error, we're going to get an async-listener error
       t.ok(true, 'end');
-      client.connect();
+      client.connect(8001);
     }, 100);
   });
 });

--- a/test/handle.tap.js
+++ b/test/handle.tap.js
@@ -1,4 +1,4 @@
-require('../index.js');
+if (!process.addAsyncListener) require('../index.js');
 
 var test = require('tap').test;
 var net = require('net');


### PR DESCRIPTION
This fixes some of the issues discovered in #26.

The "Object #<Object> has no method 'listener'" error is due to an API change in AsyncListener. Not sure how to deal with that. Impacted versions are 0.11.9 and 0.11.10.

Other than the listener issue, they appear to all be test-related issues.