### PR TITLE
Fix timer patches in iojs 1.6.3+

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,11 +112,22 @@ var asynchronizers = [
 ];
 if (global.setImmediate) asynchronizers.push('setImmediate');
 
+var timers = require('timers');
+var patchGlobalTimers = global.setTimeout === timers.setTimeout;
+
 massWrap(
-  require('timers'),
+  timers,
   asynchronizers,
   activatorFirst
 );
+
+if (patchGlobalTimers) {
+  massWrap(
+    global,
+    asynchronizers,
+    activatorFirst
+  );
+}
 
 var dns = require('dns');
 massWrap(


### PR DESCRIPTION
Timer functions are now mounted directly on global as of iojs 1.6.3
See: https://github.com/iojs/io.js/pull/1280