### PR TITLE
Bug fix - listener leaks in case of nested wrapped methods and an error in the method

### DIFF
--- a/test/double-calls-to-create-if-importing-domain-after-async-listener.tap.js
+++ b/test/double-calls-to-create-if-importing-domain-after-async-listener.tap.js
@@ -1,0 +1,74 @@
+var test = require('tap').test;
+if (!process.addAsyncListener) require('../index.js');
+var domain = require('domain');
+
+/**
+ * if we import domains after async-listener, the domain import causes process.nextTick to call async listener twice.
+ * The reason is because domain replaces the underlying _currentTickHandler. If domain is loaded after async listener,
+ * the _currentTickHandler method is replaced with a wrapped method (wrapped by async listener).
+ *
+ * The net result is that
+ * if we load async-listener, then domain, we will have both process.nextTick and _currentTickHandler wrapped.
+ *
+ * if we load domain, then async-listener, we will have only process.nextTick wrapped.
+ *
+ * This double wrapping causes another issue - if we have an exception in the async method, asycn-listener does not expect a method
+ * to be wrapped twice and will only pop the listenerStack once, making calls after that that should not respond to the listener do be effected.
+ *
+ * **/
+test("asyncListeners with domains", function (t) {
+    t.plan(2);
+
+    t.test("illustration of the problem - create is called twice", function(t) {
+        t.plan(1);
+        var callsToCreate = 0;
+        var listener = process.createAsyncListener(
+            {
+                create : function () { callsToCreate++; },
+                before : function () {},
+                after  : function () {},
+                error  : function () {}
+            }
+        );
+
+        process.addAsyncListener(listener);
+        process.nextTick(function Func() {
+            t.equal(callsToCreate, 2, "number of calls to create");
+        });
+        process.removeAsyncListener(listener);
+
+
+    });
+
+    t.test("validate that async listener create is not called for a tick executed after a listened on tick with an error", function(t) {
+        t.plan(2);
+        var asyncListenedMethodDone = false;
+        var callsToCreate = 0;
+        var listener = process.createAsyncListener(
+            {
+                create : function () { callsToCreate++; },
+                before : function () {},
+                after  : function () {},
+                error  : function () {return true;}
+            }
+        );
+
+        process.addAsyncListener(listener);
+        process.nextTick(function Func() {
+            asyncListenedMethodDone = true;
+            throw new Error("Bla");
+        });
+        process.removeAsyncListener(listener);
+
+        // wait until the error was raised and then perform async operation
+        var timer = setInterval(function() {
+            if (asyncListenedMethodDone) {
+                t.equal(callsToCreate, 2, "number of calls to create - before the async method");
+                clearInterval(timer);
+                process.nextTick(function() {
+                    t.equal(callsToCreate, 2, "number of calls to create - in the async method (who should not be listened on by async the registered listener");
+                })
+            }
+        }, 1);
+    })
+});

--- a/test/double-calls-to-create-not-happening-if-importing-domain-before-async-listener.tap.js
+++ b/test/double-calls-to-create-not-happening-if-importing-domain-before-async-listener.tap.js
@@ -1,0 +1,74 @@
+var domain = require('domain');
+var test = require('tap').test;
+if (!process.addAsyncListener) require('../index.js');
+
+/**
+ * if we import domains after async-listener, the domain import causes process.nextTick to call async listener twice.
+ * The reason is because domain replaces the underlying _currentTickHandler. If domain is loaded after async listener,
+ * the _currentTickHandler method is replaced with a wrapped method (wrapped by async listener).
+ *
+ * The net result is that
+ * if we load async-listener, then domain, we will have both process.nextTick and _currentTickHandler wrapped.
+ *
+ * if we load domain, then async-listener, we will have only process.nextTick wrapped.
+ *
+ * This double wrapping causes another issue - if we have an exception in the async method, asycn-listener does not expect a method
+ * to be wrapped twice and will only pop the listenerStack once, making calls after that that should not respond to the listener do be effected.
+ *
+ * **/
+test("asyncListeners with domains", function (t) {
+    t.plan(2);
+
+    t.test("illustration of the problem - create is called twice", function(t) {
+        t.plan(1);
+        var callsToCreate = 0;
+        var listener = process.createAsyncListener(
+            {
+                create : function () { callsToCreate++; },
+                before : function () {},
+                after  : function () {},
+                error  : function () {}
+            }
+        );
+
+        process.addAsyncListener(listener);
+        process.nextTick(function Func() {
+            t.equal(callsToCreate, 1, "number of calls to create");
+        });
+        process.removeAsyncListener(listener);
+
+
+    });
+
+    t.test("validate that async listener create is not called for a tick executed after a listened on tick with an error", function(t) {
+        t.plan(2);
+        var asyncListenedMethodDone = false;
+        var callsToCreate = 0;
+        var listener = process.createAsyncListener(
+            {
+                create : function () { callsToCreate++; },
+                before : function () {},
+                after  : function () {},
+                error  : function () {return true;}
+            }
+        );
+
+        process.addAsyncListener(listener);
+        process.nextTick(function Func() {
+            asyncListenedMethodDone = true;
+            throw new Error("Bla");
+        });
+        process.removeAsyncListener(listener);
+
+        // wait until the error was raised and then perform async operation
+        var timer = setInterval(function() {
+            if (asyncListenedMethodDone) {
+                t.equal(callsToCreate, 1, "number of calls to create - before the async method");
+                clearInterval(timer);
+                process.nextTick(function() {
+                    t.equal(callsToCreate, 1, "number of calls to create - in the async method (who should not be listened on by async the registered listener");
+                })
+            }
+        }, 1);
+    })
+});


### PR DESCRIPTION
The bug is subtle but still there - 
If we have two nested methods that are both wrapped by ```glue.js```, the result is that create will be called twice for the same tick. This by itself is not a big problem. The important thing is that the list of listeners is pushed twice into ```listenersStack```

However, if the callback passed to those two have an exception, the ```asyncCatcher``` method in glue.js 
only pops ```listenersStack``` once. 

Once example where this may happen is if we import domains after async-listener, the domain import causes ```process.nextTick``` to call async listener twice. The reason is because domain replaces the underlying ```_currentTickHandler``` method. If domain is loaded after async listener, the ```_currentTickHandler``` method is replaced with a wrapped method (wrapped by async listener).

The net result is that
if we load async-listener, then domain, we will have both ```process.nextTick``` and ```_currentTickHandler``` wrapped.

if we load domain, then async-listener, we will have only ```process.nextTick``` wrapped.

I have included two new test files to demonstrate the two cases as well as a fix to the problem. Just run the test cases without the fix and you can see the problem.

See the files
```double-calls-to-create-if-importing-domain-after-async-listener.tap.js```
```double-calls-to-create-not-happening-if-importing-domain-before-async-listener.tap.js```


Also note that the problem is not local to just domains. I have noticed that using ```fs.readFile``` calls ```fs.open``` directly passing the same callback, resulting in nested wrapped methods and the same issue.