### PR TITLE
Fix process.nextTick vararg support

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ if (!process._fatalException) {
   process._originalNextTick = process.nextTick;
 }
 
-var processors = ['nextTick'];
+var processors = [];
 if (process._nextDomainTick) processors.push('_nextDomainTick');
 if (process._tickDomainCallback) processors.push('_tickDomainCallback');
 
@@ -106,6 +106,7 @@ massWrap(
   processors,
   activator
 );
+wrap(process, 'nextTick', activatorFirst);
 
 var asynchronizers = [
   'setTimeout',

--- a/test/overlapping-nexttick.tap.js
+++ b/test/overlapping-nexttick.tap.js
@@ -177,7 +177,7 @@ test("overlapping requests", function (t) {
       t.ok(getTransaction(), "transaction should be visible");
 
       first = getTransaction().id;
-      process.nextTick(function () { handler(first); });
+      process.nextTick(function () { handler(first); }, 42);
     });
     proxied();
 
@@ -186,7 +186,7 @@ test("overlapping requests", function (t) {
 
       var second = getTransaction().id;
       t.notEqual(first, second, "different transaction IDs");
-      process.nextTick(function () { handler(second); });
-    }));
+      process.nextTick(function () { handler(second); }, 42);
+    }), 42);
   });
 });


### PR DESCRIPTION
io.js 1.8.1 introduces support for additional arguments that are forwarded to the callback passed into `process.nextTick`. This means it's now important that the first argument and not the last argument is instrumented. See: https://github.com/nodejs/io.js/commit/10e31ba56c676bdcad39ccad22ea9117733b8eb5

Tested against io.js 1.7.1, 1.8.1, 2.4.0, and node 0.10.40. The additional arguments to `nextTick` are just noops in versions before 1.8.1.