### PR TITLE
Handle spawn, exec, execFile

### DIFF
--- a/test/spawn.tap.js
+++ b/test/spawn.tap.js
@@ -1,0 +1,100 @@
+var test   = require('tap').test
+  , assert = require('assert')
+  ;
+
+if (!global.setImmediate) global.setImmediate = setTimeout;
+
+if (!process.addAsyncListener) require('../index.js');
+
+var childProcess = require('child_process')
+  , exec         = childProcess.exec
+  , execFile     = childProcess.execFile
+  , spawn        = childProcess.spawn
+  ;
+
+test('ChildProcess', function (t) {
+  t.plan(3);
+
+  t.test('exec', function (t) {
+    t.plan(3);
+
+    var active
+      , cntr   = 0
+      ;
+
+    process.addAsyncListener(
+      {
+        create : function () { return { val : ++cntr }; },
+        before : function (context, data) { active = data.val; },
+        after  : function () { active = null; }
+      }
+    );
+
+    t.equal(active, undefined,
+      'starts in initial context');
+    process.nextTick(function () {
+      t.equal(active, 1,
+        'after tick: 1st context');
+      var child = exec('node --version');
+      child.on('exit', function (code) {
+        t.ok(active >= 2,
+          'after exec#exit: entered additional contexts');
+      })
+    });
+  });
+
+  t.test('execFile', function (t) {
+    t.plan(3);
+
+    var active
+      , cntr   = 0
+      ;
+
+    process.addAsyncListener(
+      {
+        create : function () { return { val : ++cntr }; },
+        before : function (context, data) { active = data.val; },
+        after  : function () { active = null; }
+      }
+    );
+
+    t.equal(active, undefined,
+      'starts in initial context');
+    process.nextTick(function () {
+      t.equal(active, 1,
+        'after nextTick: 1st context');
+      execFile('node', ['--version'], function (err, code) {
+        t.ok(active >= 2,
+          'after execFile: entered additional contexts');
+      });
+    });
+  });
+
+  t.test('spawn', function (t) {
+    t.plan(3);
+
+    var active
+      , cntr   = 0
+      ;
+
+    process.addAsyncListener(
+      {
+        create : function () { return { val : ++cntr }; },
+        before : function (context, data) { active = data.val; },
+        after  : function () { active = null; }
+      }
+    );
+
+    t.equal(active, undefined,
+      'starts in initial context');
+    process.nextTick(function () {
+      t.equal(active, 1,
+        'after tick: 1st context');
+      var child = spawn('node', ['--version']);
+      child.on('exit', function (code) {
+        t.ok(active >= 2,
+          'after spawn#exit: entered additional contexts');
+      })
+    });
+  });
+});


### PR DESCRIPTION
I'm not 100% sure if this was working as designed or is a bug/missing feature. With these changes `cp.execFile(..., () => {})` is correctly tracked across async boundaries, assuming that the `exit` event is considered a valid async boundary.

Instrumenting the stdio handles was required because there's magic that automatically tracks reads and close events and turns them into exit once the last stdio stream closes.

I tested the change with latest node 0.10 and 4.