### PR TITLE
Fix promise test on node v6

### DIFF
--- a/test/native-promises.tap.js
+++ b/test/native-promises.tap.js
@@ -7,6 +7,10 @@ var resolvedBeforeWrap = unwrappedPromise.resolve(123)
 
 require('../index.js');
 
+// Convert semver string to number set
+// TODO: This is *very* naive structure to check versions with,
+// but it works well enough for now...
+var nodeVersion = process.version.slice(1).split('.').map(Number)
 
 test('then', function(t) {
   var listener = addListner();
@@ -950,6 +954,35 @@ test('then chain with promise', function(t) {
 
   process.removeAsyncListener(listener.listener);
 
+  // Promise resolution changed slightly in node v6,
+  // now resolve/reject wraps again on completion.
+  var children = []
+  if (nodeVersion[0] >= 6) {
+    children.push({
+      name: 'accept from nextTick',
+      children: [],
+      before: 0,
+      after: 0,
+      error: 0
+    })
+  }
+  children.push(
+    {
+      name: 'setTimeout in 2nd then',
+      children: [],
+      before: 1,
+      after: 0,
+      error: 0
+    },
+    {
+      name: '2nd then continuation',
+      children: [],
+      before: 0,
+      after: 0,
+      error: 0
+    }
+  )
+
   var expected = {
     name: 'root',
     children: [
@@ -961,24 +994,9 @@ test('then chain with promise', function(t) {
             children: [
               {
                 name: 'accept from nextTick',
-                children: [
-                  {
-                    name: 'setTimeout in 2nd then',
-                    children: [],
-                    before: 1,
-                    after: 0,
-                    error: 0
-                  },
-                  {
-                    name: '2nd then continuation',
-                    children: [],
-                    before: 0,
-                    after: 0,
-                    error: 0
-                  }
-                ],
-                before: 1,
-                after: 1,
+                children: children,
+                before: children.length - 1,
+                after: children.length - 1,
                 error: 0
               }
             ],
@@ -1029,6 +1047,35 @@ test('multi chain with promise', function(t) {
 
   process.removeAsyncListener(listener.listener);
 
+  // Promise resolution changed slightly in node v6,
+  // now resolve/reject wraps again on completion.
+  var children = []
+  if (nodeVersion[0] >= 6) {
+    children.push({
+      name: 'accept from nextTick',
+      children: [],
+      before: 0,
+      after: 0,
+      error: 0
+    })
+  }
+  children.push(
+    {
+      name: 'setTimeout in 2nd chain',
+      children: [],
+      before: 1,
+      after: 0,
+      error: 0
+    },
+    {
+      name: '2nd then continuation',
+      children: [],
+      before: 0,
+      after: 0,
+      error: 0
+    }
+  )
+
   var expected = {
     name: 'root',
     children: [
@@ -1040,24 +1087,9 @@ test('multi chain with promise', function(t) {
             children: [
               {
                 name: 'accept from nextTick',
-                children: [
-                  {
-                    name: 'setTimeout in 2nd chain',
-                    children: [],
-                    before: 1,
-                    after: 0,
-                    error: 0
-                  },
-                  {
-                    name: '2nd then continuation',
-                    children: [],
-                    before: 0,
-                    after: 0,
-                    error: 0
-                  }
-                ],
-                before: 1,
-                after: 1,
+                children: children,
+                before: children.length - 1,
+                after: children.length - 1,
                 error: 0
               }
             ],
@@ -1124,6 +1156,35 @@ test('then chain with rejected promise', function(t) {
 
   process.removeAsyncListener(listener.listener);
 
+  // Promise resolution changed slightly in node v6,
+  // now resolve/reject wraps again on completion.
+  var children = []
+  if (nodeVersion[0] >= 6) {
+    children.push({
+      name: 'reject from nextTick',
+      children: [],
+      before: 0,
+      after: 0,
+      error: 0
+    })
+  }
+  children.push(
+    {
+      name: 'setTimeout in 2nd then',
+      children: [],
+      before: 1,
+      after: 0,
+      error: 0
+    },
+    {
+      name: '2nd then continuation',
+      children: [],
+      before: 0,
+      after: 0,
+      error: 0
+    }
+  )
+
   var expected = {
     name: 'root',
     children: [
@@ -1135,24 +1196,9 @@ test('then chain with rejected promise', function(t) {
             children: [
               {
                 name: 'reject from nextTick',
-                children: [
-                  {
-                    name: 'setTimeout in 2nd then',
-                    children: [],
-                    before: 1,
-                    after: 0,
-                    error: 0
-                  },
-                  {
-                    name: '2nd then continuation',
-                    children: [],
-                    before: 0,
-                    after: 0,
-                    error: 0
-                  }
-                ],
-                before: 1,
-                after: 1,
+                children: children,
+                before: children.length - 1,
+                after: children.length - 1,
                 error: 0
               }
             ],
@@ -1219,6 +1265,35 @@ test('multi chain with rejected promise', function(t) {
 
   process.removeAsyncListener(listener.listener);
 
+  // Promise resolution changed slightly in node v6,
+  // now resolve/reject wraps again on completion.
+  var children = []
+  if (nodeVersion[0] >= 6) {
+    children.push({
+      name: 'reject from nextTick',
+      children: [],
+      before: 0,
+      after: 0,
+      error: 0
+    })
+  }
+  children.push(
+    {
+      name: 'setTimeout in 2nd chain',
+      children: [],
+      before: 1,
+      after: 0,
+      error: 0
+    },
+    {
+      name: '2nd chain continuation',
+      children: [],
+      before: 0,
+      after: 0,
+      error: 0
+    }
+  )
+
   var expected = {
     name: 'root',
     children: [
@@ -1230,24 +1305,9 @@ test('multi chain with rejected promise', function(t) {
             children: [
               {
                 name: 'reject from nextTick',
-                children: [
-                  {
-                    name: 'setTimeout in 2nd chain',
-                    children: [],
-                    before: 1,
-                    after: 0,
-                    error: 0
-                  },
-                  {
-                    name: '2nd chain continuation',
-                    children: [],
-                    before: 0,
-                    after: 0,
-                    error: 0
-                  }
-                ],
-                before: 1,
-                after: 1,
+                children: children,
+                before: children.length - 1,
+                after: children.length - 1,
                 error: 0
               }
             ],
@@ -1309,6 +1369,35 @@ test('multi catch with promise', function(t) {
 
   process.removeAsyncListener(listener.listener);
 
+  // Promise resolution changed slightly in node v6,
+  // now resolve/reject wraps again on completion.
+  var children = []
+  if (nodeVersion[0] >= 6) {
+    children.push({
+      name: 'reject from nextTick',
+      children: [],
+      before: 0,
+      after: 0,
+      error: 0
+    })
+  }
+  children.push(
+    {
+      name: 'setTimeout in 2nd catch',
+      children: [],
+      before: 1,
+      after: 0,
+      error: 0
+    },
+    {
+      name: '2nd catch continuation',
+      children: [],
+      before: 0,
+      after: 0,
+      error: 0
+    }
+  )
+
   var expected = {
     name: 'root',
     children: [
@@ -1320,24 +1409,9 @@ test('multi catch with promise', function(t) {
             children: [
               {
                 name: 'reject from nextTick',
-                children: [
-                  {
-                    name: 'setTimeout in 2nd catch',
-                    children: [],
-                    before: 1,
-                    after: 0,
-                    error: 0
-                  },
-                  {
-                    name: '2nd catch continuation',
-                    children: [],
-                    before: 0,
-                    after: 0,
-                    error: 0
-                  }
-                ],
-                before: 1,
-                after: 1,
+                children: children,
+                before: children.length - 1,
+                after: children.length - 1,
                 error: 0
               }
             ],
@@ -1543,11 +1617,12 @@ test('resume context after unwrapped promise', function(t) {
   var listener = addListner();
 
   listener.currentName = 'resolve';
-  var wrapped = Promise.resolve(456)
+  var wrapped = Promise.resolve(456);
 
   listener.currentName = 'unwrapped resolve';
   resolvedBeforeWrap.then(function(val) {
     t.equal(val, 123, 'should match resolved value');
+    listener.currentName = 'maybe internal resolve';
     return wrapped
   }).then(function (val) {
     t.equal(val, 456, 'should match resolved value');
@@ -1561,19 +1636,33 @@ test('resume context after unwrapped promise', function(t) {
 
   process.removeAsyncListener(listener.listener);
 
+  // Promise resolution changed slightly in node v6,
+  // now resolve/reject wraps again on completion.
+  var children = []
+  if (nodeVersion[0] >= 6) {
+    children.push({
+      name : 'maybe internal resolve',
+      children : [],
+      before : 0,
+      after : 0,
+      error : 0
+    })
+  }
+  children.push({
+    name : 'return after continuing from wrapped promise',
+    children : [],
+    before : 1,
+    after : 0,
+    error : 0
+  })
+
   var expected = {
     name: 'root',
     children: [{
       name : 'resolve',
-      children : [{
-        name : 'return after continuing from wrapped promise',
-        children : [],
-        before : 1,
-        after : 0,
-        error : 0
-      }],
-      before : 1,
-      after : 1,
+      children : children,
+      before : children.length,
+      after : children.length,
       error : 0
     }],
     before: 0,


### PR DESCRIPTION
Promises changed a bit in node v6, so they now produce a slightly different resulting call graph from async-listener.