### PR TITLE
Fix breaking change in Node.js v7.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "node": "<=0.11.8 || >0.11.10"
   },
   "dependencies": {
+    "semver": "^5.3.0",
     "shimmer": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Back in Node.js version 7.0.0, the `net._normalizeConnectArgs` function was renamed to `net._normalizeArgs`. This didn't immediately break the code as we now simply detected that the function was missing and added a polyfill instead.

As long as this polyfill behaved like the new `net._normalizeArgs` function all was good. But in Node.js v7.7.2, its behavior changed and the polyfill no longer worked as expected.

This commit fixes this by correctly detecting if we are running version 7.0.0 or higher and expecting the function to be called `_normalizeArgs`.

A new polyfill have been added for this function in case it's ever removed.