### PR TITLE
update argument management in net.Socket.prototype.connect to handle node 8

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ wrap(net.Socket.prototype, 'connect', function (original) {
     var args = v7plus
       ? net._normalizeArgs(arguments)
       : net._normalizeConnectArgs(arguments);
+    if (Array.isArray(args[0])) args = args[0]
     if (args[1]) args[1] = wrapCallback(args[1]);
     var result = original.apply(this, args);
     patchOnRead(this);


### PR DESCRIPTION
Tested with node v8.0.0-rc.0.

The signature of net._normalizeArgs has been changed [in node core](https://github.com/nodejs/node/commit/53f386932209ae375c3cf811329483e30868f3ac). I belive it leads to an issue in async-listner:

I have been having issue while performing http request from a process where the CLS in instanciated (https://gist.github.com/vdeturckheim/5d96705298a55a90a25716314edd449e).

This change fixes my issue and fixes the tests of async-listener with node v8.0.0-rc.0.

CC @joyeecheung @mcollina @jasnell