### PR TITLE
Add Node.js 8 to Travis CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
     - node_modules
 
 node_js:
+  - "8"
   - "7"
   - "6"
   - "5"


### PR DESCRIPTION
The tests are currently failing on Node.js 8 and I'm not that familiar with the test suite yet, so I need some help reading the output and hopefully making the tests pass.

There's already a PR open that fixes some of the tests, but not all of them (#110).

If someone could explain how to interpret the error output from the tests, it would be awesome 😃 