### PR TITLE
Allow failures on latest Node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ node_js:
 
 matrix:
   allow_failures:
-    - node_js: 3
-    - node_js: 5
-    - node_js: 7
+    - node_js: '3'
+    - node_js: '5'
+    - node_js: '7'
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 
 node_js:
   - "7"
+  - "7.9.0"
   - "6"
   - "5"
   - "4"
@@ -17,5 +18,6 @@ matrix:
   allow_failures:
     - node_js: 3
     - node_js: 5
+    - node_js: 7
 
 sudo: false


### PR DESCRIPTION
Because issue https://github.com/othiym23/async-listener/issues/109 have not yet been solved for Node.js 7, the test suite currently fails when running on the latest version of Node.js 7 (v7.10.0 as of this commit).

This commit allows 7.x to fail, but adds an extra build for 7.9.0 which is know to be good.

This should be reverted when/if Node.js 7 is patched accordingly.