### PR TITLE
remove support for `crypto.pseudoRandomBytes` in node 11+

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var shimmer      = require('shimmer')
 var v6plus = semver.gte(process.version, '6.0.0');
 var v7plus = semver.gte(process.version, '7.0.0');
 var v8plus = semver.gte(process.version, '8.0.0');
+var v11plus = semver.gte(process.version, '11.0.0');
 
 var net = require('net');
 
@@ -334,7 +335,7 @@ if (crypto) {
       'pbkdf2',
       'randomBytes',
   ];
-  if (semver.lt(process.version, '11.0.0')) {
+  if (v11plus) {
     toWrap.push('pseudoRandomBytes');
   }
 

--- a/index.js
+++ b/index.js
@@ -329,15 +329,16 @@ if (zlib && zlib.Deflate && zlib.Deflate.prototype) {
 var crypto;
 try { crypto = require('crypto'); } catch (err) { }
 if (crypto) {
-  massWrap(
-    crypto,
-    [
+
+  const toWrap = [
       'pbkdf2',
       'randomBytes',
-      'pseudoRandomBytes',
-    ],
-    activator
-  );
+  ];
+  if (semver.lt(process.version, '11.0.0')) {
+    toWrap.push('pseudoRandomBytes');
+  }
+
+  massWrap(crypto, toWrap, activator);
 }
 
 // It is unlikely that any userspace promise implementations have a native

--- a/index.js
+++ b/index.js
@@ -331,7 +331,7 @@ var crypto;
 try { crypto = require('crypto'); } catch (err) { }
 if (crypto) {
 
-  const toWrap = [
+  var toWrap = [
       'pbkdf2',
       'randomBytes',
   ];


### PR DESCRIPTION
fixes #137 