### PR TITLE
Fix library from rollup compilation

### DIFF
--- a/glue.js
+++ b/glue.js
@@ -480,9 +480,12 @@ function removeAsyncListener(listener) {
     }
   }
 }
-
-process.createAsyncListener = createAsyncListener;
-process.addAsyncListener    = addAsyncListener;
-process.removeAsyncListener = removeAsyncListener;
-
-module.exports = wrapCallback;
+function initProcess() {
+  process.createAsyncListener = createAsyncListener;
+  process.addAsyncListener    = addAsyncListener;
+  process.removeAsyncListener = removeAsyncListener;
+}
+module.exports = {
+  wrapCallback: wrapCallback,
+  initProcess: initProcess
+};

--- a/index.js
+++ b/index.js
@@ -6,9 +6,11 @@ var shimmer      = require('shimmer')
   , semver       = require('semver')
   , wrap         = shimmer.wrap
   , massWrap     = shimmer.massWrap
-  , wrapCallback = require('./glue.js')
+  , glue = require('./glue.js')
+  , wrapCallback = glue.wrapCallback
   , util         = require('util')
   ;
+glue.initProcess();
 
 var v6plus = semver.gte(process.version, '6.0.0');
 var v7plus = semver.gte(process.version, '7.0.0');


### PR DESCRIPTION
Hello,
I have detected a problem explained in this repository:
https://github.com/uurien/async-listener-demo

The order of code isn't exactly the same after compilation as dependency, and process.addAsyncListener is always filled before comprobation.

In this pull request I have fixed it, here is an example:
https://github.com/uurien/async-listener-demo/tree/pull-request-demo
Regards