### PR TITLE
Fix bug activator function object missing properties (fs.realpath.native is undefined)

### DIFF
--- a/index.js
+++ b/index.js
@@ -567,43 +567,43 @@ function activator(fn) {
   // Preserve function length for small arg count functions.
   switch (fn.length) {
     case 1:
-      return function (cb) {
+      return Object.assign(function (cb) {
         if (arguments.length !== 1) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, cb);
-      };
+      }, fn);
     case 2:
-      return function (a, cb) {
+      return Object.assign(function (a, cb) {
         if (arguments.length !== 2) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, a, cb);
-      };
+      }, fn);
     case 3:
-      return function (a, b, cb) {
+      return Object.assign(function (a, b, cb) {
         if (arguments.length !== 3) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, a, b, cb);
-      };
+      }, fn);
     case 4:
-      return function (a, b, c, cb) {
+      return Object.assign(function (a, b, c, cb) {
         if (arguments.length !== 4) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, a, b, c, cb);
-      };
+      }, fn);
     case 5:
-      return function (a, b, c, d, cb) {
+      return Object.assign(function (a, b, c, d, cb) {
         if (arguments.length !== 5) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, a, b, c, d, cb);
-      };
+      }, fn);
     case 6:
-      return function (a, b, c, d, e, cb) {
+      return Object.assign(function (a, b, c, d, e, cb) {
         if (arguments.length !== 6) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, a, b, c, d, e, cb);
-      };
+      }, fn);
     default:
-      return fallback;
+      return Object.assign(fallback, fn);
   }
 }
 
@@ -623,43 +623,43 @@ function activatorFirst(fn) {
   // Preserve function length for small arg count functions.
   switch (fn.length) {
     case 1:
-      return function (cb) {
+      return Object.assign(function (cb) {
         if (arguments.length !== 1) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, cb);
-      };
+      }, fn);
     case 2:
-      return function (cb, a) {
+      return Object.assign(function (cb, a) {
         if (arguments.length !== 2) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, cb, a);
-      };
+      }, fn);
     case 3:
-      return function (cb, a, b) {
+      return Object.assign(function (cb, a, b) {
         if (arguments.length !== 3) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, cb, a, b);
-      };
+      }, fn);
     case 4:
-      return function (cb, a, b, c) {
+      return Object.assign(function (cb, a, b, c) {
         if (arguments.length !== 4) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, cb, a, b, c);
-      };
+      }, fn);
     case 5:
-      return function (cb, a, b, c, d) {
+      return Object.assign(function (cb, a, b, c, d) {
         if (arguments.length !== 5) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, cb, a, b, c, d);
-      };
+      }, fn);
     case 6:
-      return function (cb, a, b, c, d, e) {
+      return Object.assign(function (cb, a, b, c, d, e) {
         if (arguments.length !== 6) return fallback.apply(this, arguments);
         if (typeof cb === "function") cb = wrapCallback(cb);
         return fn.call(this, cb, a, b, c, d, e);
-      };
+      }, fn);
     default:
-      return fallback;
+      return Object.assign(fallback, fn);
   }
 }
 


### PR DESCRIPTION
Hey, 
This pr is aiming to solve this issue: #143 
This sandbox replicate the issue: [sandbox](https://codesandbox.io/s/great-glitter-xnwq3?file=/src/index.js)

Initially I was getting `fs.realpath.native` as `undefined`  when using `continuation-local-storage` which is using `async-listener` as dependency. And `continuation-local-storage` in conjunction with `fs-extra` v10 are throwing this [error](https://codesandbox.io/s/priceless-galois-n4oud?file=/src/index.js). 
So in this particular case, I traced the issue to [here](https://github.com/othiym23/async-listener/blob/master/index.js#L582).  What's happening is that we are returning the wrapper without the original function object properties. 

This shallow copy should be solve the problem by attaching the original function object properties to the wrapper function.